### PR TITLE
Fix parsing error on progress 'N/A' values

### DIFF
--- a/ffmpeg/utils.py
+++ b/ffmpeg/utils.py
@@ -48,11 +48,21 @@ def parse_progress(line):
     if not items:
         return None
 
+    if items['size'] == 'N/A':
+        size = None
+    else:
+        size = int(items['size'].replace('kB', '')) * 1024
+
+    if items['bitrate'] == 'N/A':
+        bitrate = None
+    else:
+        bitrate = float(items['size'].replace('kbits/s', ''))
+
     return Progress(
         frame=int(items['frame']),
         fps=float(items['fps']),
-        size=int(items['size'].replace('kB', '')) * 1024,
+        size=size,
         time=items['time'],
-        bitrate=float(items['bitrate'].replace('kbits/s', '')),
+        bitrate=bitrate,
         speed=float(items['speed'].replace('x', '')),
     )

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='python-ffmpeg',
-    version='1.0.7',
+    version='1.0.8',
     description='A python interface for FFmpeg',
     url='https://github.com/jonghwanhyeon/python-ffmpeg',
     author='Jonghwan Hyeon',


### PR DESCRIPTION
Hey, came across your package today, it's just what I need, and by sheer coincidence your example is using rtsp, which is what I need to do.

I ran into an error where the ffmpeg progress statements have a value of `N/A` for size and bitrate when the output is using segmenting (at least I think that's the cause).

Here's the ffmpeg options I'm using:

```python
ffmpeg = FFmpeg().option('y').input(
    uri,
    rtsp_transport='udp'
).output(
    path + 'output_%H:%M:%S.ts',
    {'codec:v': 'copy'},
    f='segment',
    segment_time='10',
    segment_format='mpegts',
    reset_timestamps='1',
    strftime='1',
)
```

Which would result in:

```
ValueError: invalid literal for int() with base 10: 'N/A'
```

Cheers!