### PR TITLE
Add support for stream mapping

### DIFF
--- a/ffmpeg/ffmpeg.py
+++ b/ffmpeg/ffmpeg.py
@@ -33,6 +33,7 @@ class FFmpeg(EventEmitter):
         self._executable = executable
         self._global_options = {}
         self._input_files = []
+        self._mappings = []
         self._output_files = []
 
         self._executed = False
@@ -50,6 +51,10 @@ class FFmpeg(EventEmitter):
             options = {}
 
         self._input_files.append(FFmpeg._File(url=url, options={**options, **kwargs}))
+        return self
+
+    def map(self, value):
+        self._mappings.append(value)
         return self
 
     def output(self, url, options=None, **kwargs):
@@ -122,6 +127,9 @@ class FFmpeg(EventEmitter):
         for file in self._input_files:
             arguments.extend(build_options(file.options))
             arguments.extend(['-i', file.url])
+
+        for mapping in self._mappings:
+            arguments.extend(build_options({'map': mapping}))
 
         for file in self._output_files:
             arguments.extend(build_options(file.options))


### PR DESCRIPTION
Mapping comes on a command line after inputs and before outputs.
It's specified using `-map <mapping>` argument and can be passed
multiple times to handle multiple streams.

Currently, mapping can be passed as output argument, but only as long
as you use only one mapping (which is not so common really).

More info can be found [here](https://trac.ffmpeg.org/wiki/Map).

Thanks for your great work on the library! 💪 🚀 