### PR TITLE
Fix DeprecationWarning

### DIFF
--- a/ffmpeg/ffmpeg.py
+++ b/ffmpeg/ffmpeg.py
@@ -74,9 +74,9 @@ class FFmpeg(EventEmitter):
 
         self._executed = True
         await asyncio.wait([
-            self._write_stdin(stream),
-            self._read_stderr(),
-            self._process.wait(),
+            asyncio.create_task(self._write_stdin(stream)),
+            asyncio.create_task(self._read_stderr()),
+            asyncio.create_task(self._process.wait()),
         ])
 
         if self._process.returncode == 0:


### PR DESCRIPTION
The explicit passing of coroutine objects to asyncio.wait() is deprecated since Python 3.8, and scheduled for removal in Python 3.11
