### PR TITLE
Expose stdin.drain() to create back pressure

### DIFF
--- a/ffmpeg/ffmpeg.py
+++ b/ffmpeg/ffmpeg.py
@@ -109,6 +109,11 @@ class FFmpeg(EventEmitter):
         self._terminated = True
         self._process.send_signal(sigterm)
 
+    async def drain(self):
+        # Memory leak occurs when too much data is feed to StreamReader (stream)
+        # So expose StreamWriter's (stdin) drain to be called to create back pressure
+        return await self._process.stdin.drain()
+
     async def _write_stdin(self, stream: Optional[StreamReader]):
         if stream is None:
             return

--- a/ffmpeg/ffmpeg.py
+++ b/ffmpeg/ffmpeg.py
@@ -32,7 +32,7 @@ class FFmpegError(Exception):
 class FFmpeg(EventEmitter):
     _File = namedtuple('_File', ['url', 'options'])
 
-    def __init__(self, executable: str = 'ffmpeg'):
+    def __init__(self, executable: str = 'ffmpeg', skip_default_drain: bool = False):
         super().__init__()
 
         self._executable = executable
@@ -43,6 +43,7 @@ class FFmpeg(EventEmitter):
         self._executed = False
         self._terminated = False
         self._process = None
+        self.skip_default_drain = skip_default_drain
 
         self.on('stderr', self._on_stderr)
 
@@ -120,6 +121,8 @@ class FFmpeg(EventEmitter):
 
         while not stream.at_eof():
             self._process.stdin.write(await stream.read(1024))
+            if not self.skip_default_drain:
+                await self._process.stdin.drain()
         self._process.stdin.write_eof()
 
     async def _read_stderr(self):


### PR DESCRIPTION
The lib uses `StreamReader` to get bytes and write to ffmpeg using a process's stdin (`StreamWriter`). The `_write_stdin()` function reads and writes as much data as possible from the stream the user provided. In some cases user stream can write faster that the ffmpeg process can read (which happened in my case) and lead to the whole file being stored on ffmpeg process's buffer.

You can reproduce this by creating a stream instance from `asyncio.StreamReader` and use the `feed_data()` and `fee_eof()` functions to send bytes and if you can call feed_data fast enough (reading bytes from file for example) the whole file will be on ffmpeg process stdin buffer. This is not good for system's with low memory or when reading files larger than available memory.

So by exposing the process's stdin `drain()` function to the users, they can wait for the buffer to reach low_watermark before feeding data to the stream aka back pressure.