### PR TITLE
Support asynchronous event handlers for asyncio API

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -54,3 +54,12 @@ This event is emitted when `FFmpeg` is successfully exited.
 
 ### `terminated`
 This event is emitted when `FFmpeg` is gracefully terminated by calling `FFmpeg.terminate()`.
+
+### `error`
+This event is emitted when an event listener raises an unhandled exception. Asynchronous API only, if `FFmpeg` is initialised with `emit_errors=True`.
+
+**Parameters:**
+
+|   Name  |   Type    |       Description       |
+|---------|-----------|-------------------------|
+| `error` | Exception | The unhandled Exception |

--- a/docs/examples/asynchronous-listeners.md
+++ b/docs/examples/asynchronous-listeners.md
@@ -1,0 +1,74 @@
+# Asyncronous Listeners
+
+When using the Asynchrous API, event listeners may be either regular functions or coroutines.
+
+``` python
+import asyncio
+
+from ffmpeg import Progress
+from ffmpeg.asyncio import FFmpeg
+
+
+async def main():
+    ffmpeg = (
+        FFmpeg()
+        .option("y")
+        .input("input.mov")
+        .output(
+            "ouptut.mp4",
+            codec="copy",
+        )
+    )
+
+    @ffmpeg.on("progress")
+    async def on_progress(progress: Progress):
+        await asyncio.sleep(1)
+        print(progress)
+    
+    @ffmpeg.on("completed")
+    def on_completed():
+        print("Completed")
+
+    await ffmpeg.execute()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())
+```
+
+Initialise `FFmpeg` with `emit_errors=True`, and any unhandled exceptions in listeners will be emitted as an `error` event instead of raised.
+
+``` python
+import asyncio
+import logging
+
+from ffmpeg import Progress
+from ffmpeg.asyncio import FFmpeg
+
+
+async def main():
+    ffmpeg = (
+        FFmpeg(emit_errors=True)
+        .option("y")
+        .input("input.mov")
+        .output(
+            "ouptut.mp4",
+            codec="copy",
+        )
+    )
+
+    @ffmpeg.on("progress")
+    async def on_progress(progress: Progress):
+        await asyncio.sleep(1)
+        logging.info(progress)
+    
+    @ffmpeg.on("error")
+    async def log_error(exc):
+        logging.error(f"Something went wrong: {exc}")
+
+    await ffmpeg.execute()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())
+```

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -14,6 +14,7 @@ nav:
     - examples/using-output-to-stdout.md
     - examples/feeding-data-to-stdin.md
     - examples/monitoring-status.md
+    - examples/asynchronous-listeners.md
   - api.md
 
 theme:

--- a/tests/test_asyncio_listeners.py
+++ b/tests/test_asyncio_listeners.py
@@ -15,7 +15,6 @@ async def test_asyncio_exception_raising(
 
     raised_error = RuntimeError("Raised error")
     caught_error = None
-    emitted_error = None
 
     ffmpeg = (
         FFmpeg()
@@ -30,17 +29,11 @@ async def test_asyncio_exception_raising(
     def raise_error_on_start(args):
         raise raised_error
 
-    @ffmpeg.on("error")
-    async def catch_emitted_error(exc):
-        nonlocal emitted_error
-        emitted_error = exc
-
     try:
         await ffmpeg.execute()
     except Exception as exc:
         caught_error = exc
 
-    assert emitted_error is None
     assert caught_error == raised_error
 
 @pytest.mark.asyncio

--- a/tests/test_asyncio_listeners.py
+++ b/tests/test_asyncio_listeners.py
@@ -1,0 +1,82 @@
+from pathlib import Path
+
+import pytest
+
+from ffmpeg.asyncio import FFmpeg
+
+
+@pytest.mark.asyncio
+async def test_asyncio_exception_raising(
+    assets_path: Path,
+    tmp_path: Path,
+):
+    source_path = assets_path / "pier-39.ts"
+    target_path = tmp_path / "pier-39.mp4"
+
+    raised_error = RuntimeError("Raised error")
+    caught_error = None
+    emitted_error = None
+
+    ffmpeg = (
+        FFmpeg()
+        .input(str(source_path))
+        .output(
+            str(target_path),
+            codec="copy",
+        )
+    )
+
+    @ffmpeg.on("start")
+    def raise_error_on_start(args):
+        raise raised_error
+
+    @ffmpeg.on("error")
+    async def catch_emitted_error(exc):
+        nonlocal emitted_error
+        emitted_error = exc
+
+    try:
+        await ffmpeg.execute()
+    except Exception as exc:
+        caught_error = exc
+
+    assert emitted_error is None
+    assert caught_error == raised_error
+
+@pytest.mark.asyncio
+async def test_asyncio_exception_emitting(
+    assets_path: Path,
+    tmp_path: Path,
+):
+    source_path = assets_path / "pier-39.ts"
+    target_path = tmp_path / "pier-39.mp4"
+
+    raised_error = RuntimeError("Raised error")
+    caught_error = None
+    emitted_error = None
+
+    ffmpeg = (
+        FFmpeg(emit_errors=True)
+        .input(str(source_path))
+        .output(
+            str(target_path),
+            codec="copy",
+        )
+    )
+
+    @ffmpeg.on("start")
+    def raise_error_on_start(args):
+        raise raised_error
+
+    @ffmpeg.on("error")
+    async def catch_emitted_error(exc):
+        nonlocal emitted_error
+        emitted_error = exc
+
+    try:
+        await ffmpeg.execute()
+    except Exception as exc:
+        caught_error = exc
+
+    assert emitted_error == raised_error
+    assert caught_error is None


### PR DESCRIPTION
Closes #24 

This updates the async version of `FFmpeg` to inherit from AsyncIOEventEmitter, allowing the use of coroutines as event handlers.

To ensure backwards compatibility, an `emit_errors` flag is added to initialisation, which must be set to True for the class to emit `error` events as per the AsyncIOEventEmitter default.

Includes documentation updates and test cases for exception handling behaviour with and without the `emit_errors` flag set.