### PR TITLE
Enable viewing sources in documentation

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -48,7 +48,7 @@ plugins:
             members_order: source
             group_by_category: false
             show_bases: true
-            show_source: false
+            show_source: true
 
 watch:
   - ffmpeg


### PR DESCRIPTION
Hi, I'd like to request for the sources to be enabled in the documentation.

WDYT