### PR TITLE
include additional test files in sdist

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,3 @@
+include tests/assets/*
+include tests/conftest.py
+include tests/helpers.py


### PR DESCRIPTION
**Context** 

In the `tests` folder, there are some resources such as `assets/*`, `helpers.py`, and `conftest.py` that are not being included in the current source distributions

1. https://github.com/jonghwanhyeon/python-ffmpeg/releases/download/v2.0.4/python-ffmpeg-2.0.4.tar.gz
1. https://files.pythonhosted.org/packages/93/1a/f865e159fc54bba3e51c18cfb2f027570f8b30ce40885e58fd67bff43e1f/python-ffmpeg-2.0.4.tar.gz (from https://pypi.org/project/python-ffmpeg/#files)

**Possible cause**

When creating the source distribution, the command `pipx run build --sdist` will only consider `test/test*.py` and [also](https://github.com/pypa/setuptools/blob/8ad627dfd580ac9cad2fd9c3a51dc173c5a38eca/setuptools/_distutils/command/sdist.py#L233-L253) `tests/test*.py`, as far as it concerns [the test scripts](https://packaging.python.org/en/latest/guides/using-manifest-in/#how-files-are-included-in-an-sdist).

**Suggestion**:
- include explicitly the additional files using the `MANIFEST.in` configuration file.