### PR TITLE
Fix documentation examples typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ def main():
         .option("y")
         .input("input.mp4")
         .output(
-            "ouptut.mp4",
+            "output.mp4",
             {"codec:v": "libx264"},
             vf="scale=1280:-1",
             preset="veryslow",
@@ -53,7 +53,7 @@ async def main():
         .option("y")
         .input("input.mp4")
         .output(
-            "ouptut.mp4",
+            "output.mp4",
             {"codec:v": "libx264"},
             vf="scale=1280:-1",
             preset="veryslow",

--- a/docs/examples/asynchronous-listeners.md
+++ b/docs/examples/asynchronous-listeners.md
@@ -15,7 +15,7 @@ async def main():
         .option("y")
         .input("input.mov")
         .output(
-            "ouptut.mp4",
+            "output.mp4",
             codec="copy",
         )
     )

--- a/docs/examples/monitoring-status.md
+++ b/docs/examples/monitoring-status.md
@@ -16,7 +16,7 @@ In **python-ffmpeg**, the processing status of ffmpeg can be monitored through e
             .option("y")
             .input("input.mp4")
             .output(
-                "ouptut.mp4",
+                "output.mp4",
                 {"codec:v": "libx264"},
                 vf="scale=1280:-1",
                 preset="veryslow",
@@ -68,7 +68,7 @@ In **python-ffmpeg**, the processing status of ffmpeg can be monitored through e
             .option("y")
             .input("input.mp4")
             .output(
-                "ouptut.mp4",
+                "output.mp4",
                 {"codec:v": "libx264"},
                 vf="scale=1280:-1",
                 preset="veryslow",

--- a/docs/examples/transcoding.md
+++ b/docs/examples/transcoding.md
@@ -16,7 +16,7 @@ For example, you can change the container of a video file without re-encoding th
             .option("y")
             .input("input.mov")
             .output(
-                "ouptut.mp4",
+                "output.mp4",
                 codec="copy",
             )
         )
@@ -47,7 +47,7 @@ For example, you can change the container of a video file without re-encoding th
             .option("y")
             .input("input.mov")
             .output(
-                "ouptut.mp4",
+                "output.mp4",
                 codec="copy",
             )
         )
@@ -77,7 +77,7 @@ You can also scale down the resolution of the video as follows.
             .option("y")
             .input("input.mov")
             .output(
-                "ouptut.mp4",
+                "output.mp4",
                 {"codec:v": "libx264", "filter:v": "scale=1280:-1"},
                 preset="veryslow",
                 crf=24,
@@ -110,7 +110,7 @@ You can also scale down the resolution of the video as follows.
             .option("y")
             .input("input.mov")
             .output(
-                "ouptut.mp4",
+                "output.mp4",
                 {"codec:v": "libx264", "filter:v": "scale=1280:-1"},
                 vf="scale=1280:-1",
                 preset="veryslow",

--- a/docs/index.md
+++ b/docs/index.md
@@ -22,7 +22,7 @@ $ pip install python-ffmpeg
             .option("y")
             .input("input.mp4")
             .output(
-                "ouptut.mp4",
+                "output.mp4",
                 {"codec:v": "libx264"},
                 vf="scale=1280:-1",
                 preset="veryslow",
@@ -51,7 +51,7 @@ $ pip install python-ffmpeg
             .option("y")
             .input("input.mp4")
             .output(
-                "ouptut.mp4",
+                "output.mp4",
                 {"codec:v": "libx264"},
                 vf="scale=1280:-1",
                 preset="veryslow",

--- a/examples/asyncio/transcode.py
+++ b/examples/asyncio/transcode.py
@@ -12,7 +12,7 @@ async def main():
         .option("y")
         .input("input.mp4")
         .output(
-            "ouptut.mp4",
+            "output.mp4",
             {"codec:v": "libx264", "filter:v": "scale=1280:-1"},
             preset="veryslow",
             crf=24,

--- a/examples/transcode.py
+++ b/examples/transcode.py
@@ -9,7 +9,7 @@ def main():
         .option("y")
         .input("input.mp4")
         .output(
-            "ouptut.mp4",
+            "output.mp4",
             {
                 "codec:v": "libx264",
                 "filter:v": "scale=1280:-1",


### PR DESCRIPTION
- ouptut.mp4 -> output.mp4