### PR TITLE
skip statistics length check (#46)

### DIFF
--- a/ffmpeg/__init__.py
+++ b/ffmpeg/__init__.py
@@ -9,4 +9,4 @@ from .errors import (
 from .ffmpeg import FFmpeg
 from .progress import Progress
 
-__version__ = "2.0.9"
+__version__ = "2.0.10"

--- a/ffmpeg/statistics.py
+++ b/ffmpeg/statistics.py
@@ -35,8 +35,6 @@ class Statistics:
     @classmethod
     def from_line(cls, line: str) -> Optional[Self]:
         statistics = {key: value for key, value in _pattern.findall(line)}
-        if len(statistics) != len(_field_factory):
-            return None
 
         fields = {key: _field_factory[key](value) for key, value in statistics.items() if value != "N/A"}
         return Statistics(**fields)


### PR DESCRIPTION
See #46, this also fixes the issue when not all statistics are shown in ffmpeg, for example if downloading a video from an url and not transcoding.
I don't know if this breaks any usecases tho... 