### PR TITLE
Since ffmpeg 7.0 the file size is shown in KiB.

### DIFF
--- a/ffmpeg/statistics.py
+++ b/ffmpeg/statistics.py
@@ -7,7 +7,7 @@ from typing import Optional
 
 from typing_extensions import Self
 
-from ffmpeg.utils import parse_time
+from ffmpeg.utils import parse_time, parse_size
 
 # Reference: https://github.com/FFmpeg/FFmpeg/blob/release/6.1/fftools/ffmpeg.c#L496
 
@@ -16,7 +16,7 @@ _pattern = re.compile(r"(frame|fps|size|time|bitrate|speed)\s*\=\s*(\S+)")
 _field_factory = {
     "frame": int,
     "fps": float,
-    "size": lambda item: int(item.replace("kB", "")) * 1024,
+    "size": parse_size,
     "time": parse_time,
     "bitrate": lambda item: float(item.replace("kbits/s", "")),
     "speed": lambda item: float(item.replace("x", "")),

--- a/ffmpeg/utils.py
+++ b/ffmpeg/utils.py
@@ -21,6 +21,14 @@ def parse_time(time: str) -> timedelta:
         milliseconds=int(match.group(4)) * 10,
     )
 
+# https://github.com/FFmpeg/FFmpeg/blob/d38bf5e08e768722096723b5c8781cd2eb18d070/fftools/ffmpeg.c#L618C53-L618C56
+def parse_size(item: str) -> int:
+    if "kB" in item:
+        return int(item.replace("kB", "")) * 1024
+    elif "KiB" in item:
+        return int(item.replace("KiB", "")) * 1024
+    else:
+        raise ValueError(f"Unknown size format: {item}")
 
 def is_windows() -> bool:
     return sys.platform == "win32"


### PR DESCRIPTION
Since ffmpeg 7.0 the file size is printed with this format: `"size=%8.0fkB time="` see [here](https://github.com/FFmpeg/FFmpeg/blob/5e45c27ba9baf576e548e226162be7e104328cc0/fftools/ffmpeg.c#L581).

This just adds a simple check for both and returns it.

Also see:
https://github.com/jonghwanhyeon/python-ffmpeg/issues/34#issuecomment-1956686827