### PR TITLE
fix decode of stderr lines

### DIFF
--- a/ffmpeg/asyncio/ffmpeg.py
+++ b/ffmpeg/asyncio/ffmpeg.py
@@ -255,11 +255,12 @@ class FFmpeg(AsyncIOEventEmitter):
     async def _handle_stderr(self) -> str:
         assert self._process.stderr is not None
 
-        line = b""
-        async for line in readlines(self._process.stderr):
-            self.emit("stderr", line.decode())
+        line = ""
+        async for line_bytes in readlines(self._process.stderr):
+            line = line_bytes.decode(errors="backslashreplace")
+            self.emit("stderr", line)
 
-        return line.decode()
+        return line
 
     def _reraise_exception(self, exception: Exception):
         raise exception

--- a/ffmpeg/ffmpeg.py
+++ b/ffmpeg/ffmpeg.py
@@ -251,9 +251,10 @@ class FFmpeg(EventEmitter):
     def _handle_stderr(self) -> str:
         assert self._process.stderr is not None
 
-        line = b""
-        for line in readlines(self._process.stderr):
-            self.emit("stderr", line.decode())
+        line = ""
+        for line_bytes in readlines(self._process.stderr):
+            line = line_bytes.decode(errors="backslashreplace")
+            self.emit("stderr", line)
 
         self._process.stderr.close()
-        return line.decode()
+        return line


### PR DESCRIPTION
Encountered a case where non-utf8 ID3 tags in _normal_ stderr output will cause exceptions in an otherwise successful process. Telling `decode()` to ignore or replace errors fixes the issue. This PR uses "backslashreplace" as the [codec error handler](https://docs.python.org/3/library/codecs.html#error-handlers), rather than the default which is "strict".

Opened https://github.com/jonghwanhyeon/python-ffmpeg/issues/57