### PR TITLE
Improve type-hints, support any AsyncIterable[bytes] as input, remove support for EOL python versions

### DIFF
--- a/ffmpeg/__init__.py
+++ b/ffmpeg/__init__.py
@@ -3,3 +3,13 @@ from .ffmpeg import FFmpeg
 from .progress import Progress
 
 __version__ = "2.0.12"
+
+__all__ = [
+    "FFmpeg",
+    "FFmpegAlreadyExecuted",
+    "FFmpegError",
+    "FFmpegFileNotFound",
+    "FFmpegInvalidCommand",
+    "FFmpegUnsupportedCodec",
+    "Progress",
+]

--- a/ffmpeg/asyncio/__init__.py
+++ b/ffmpeg/asyncio/__init__.py
@@ -1,1 +1,3 @@
 from .ffmpeg import FFmpeg
+
+__all__ = ["FFmpeg"]

--- a/ffmpeg/asyncio/ffmpeg.py
+++ b/ffmpeg/asyncio/ffmpeg.py
@@ -62,7 +62,7 @@ class FFmpeg(AsyncIOEventEmitter):
 
     def input(
         self,
-        url: Union[str, os.PathLike],
+        url: Union[str, os.PathLike[str]],
         options: Optional[dict[str, Optional[types.Option]]] = None,
         **kwargs: Optional[types.Option],
     ) -> Self:
@@ -105,7 +105,7 @@ class FFmpeg(AsyncIOEventEmitter):
 
     def output(
         self,
-        url: Union[str, os.PathLike],
+        url: Union[str, os.PathLike[str]],
         options: Optional[dict[str, Optional[types.Option]]] = None,
         **kwargs: Optional[types.Option],
     ) -> Self:

--- a/ffmpeg/ffmpeg.py
+++ b/ffmpeg/ffmpeg.py
@@ -59,7 +59,7 @@ class FFmpeg(EventEmitter):
 
     def input(
         self,
-        url: Union[str, os.PathLike],
+        url: Union[str, os.PathLike[str]],
         options: Optional[dict[str, Optional[types.Option]]] = None,
         **kwargs: Optional[types.Option],
     ) -> Self:
@@ -102,7 +102,7 @@ class FFmpeg(EventEmitter):
 
     def output(
         self,
-        url: Union[str, os.PathLike],
+        url: Union[str, os.PathLike[str]],
         options: Optional[dict[str, Optional[types.Option]]] = None,
         **kwargs: Optional[types.Option],
     ) -> Self:

--- a/ffmpeg/options.py
+++ b/ffmpeg/options.py
@@ -2,19 +2,21 @@ from __future__ import annotations
 
 import os
 from dataclasses import dataclass
-from typing import Iterable, Optional, Union
+from typing import TYPE_CHECKING, Iterable, Optional, Union
 
-from ffmpeg import types
 from ffmpeg.file import InputFile, OutputFile
+
+if TYPE_CHECKING:
+    from ffmpeg import types
 
 
 def _unpack_options(options: dict[str, Optional[types.Option]]) -> Iterable[Option]:
     for key, values in options.items():
-        if not isinstance(values, (list, set, tuple)):
-            values = [values]
-
-        for value in values:
-            yield Option(key, value)
+        if isinstance(values, (list, set, tuple)):
+            for value in values:
+                yield Option(key, value)
+        else:
+            yield Option(key, values)
 
 
 @dataclass(frozen=True)

--- a/ffmpeg/options.py
+++ b/ffmpeg/options.py
@@ -40,7 +40,7 @@ class Options:
 
     def input(
         self,
-        url: Union[str, os.PathLike],
+        url: Union[str, os.PathLike[str]],
         options: Optional[dict[str, Optional[types.Option]]] = None,
         **kwargs: Optional[types.Option],
     ):
@@ -53,7 +53,7 @@ class Options:
 
     def output(
         self,
-        url: Union[str, os.PathLike],
+        url: Union[str, os.PathLike[str]],
         options: Optional[dict[str, Optional[types.Option]]] = None,
         **kwargs: Optional[types.Option],
     ):

--- a/ffmpeg/progress.py
+++ b/ffmpeg/progress.py
@@ -2,9 +2,12 @@ from __future__ import annotations
 
 from dataclasses import asdict, dataclass
 from datetime import timedelta
+from typing import TYPE_CHECKING
 
-from ffmpeg.protocol import FFmpegProtocol
 from ffmpeg.statistics import Statistics
+
+if TYPE_CHECKING:
+    from ffmpeg.protocol import ExecuteType_co, FFmpegProtocol
 
 
 @dataclass(frozen=True)
@@ -29,7 +32,7 @@ class Progress:
 
 
 class Tracker:
-    def __init__(self, ffmpeg: FFmpegProtocol):
+    def __init__(self, ffmpeg: FFmpegProtocol[ExecuteType_co]):
         self._ffmpeg = ffmpeg
         self._ffmpeg.on("stderr", self._on_stderr)
 

--- a/ffmpeg/protocol.py
+++ b/ffmpeg/protocol.py
@@ -18,14 +18,14 @@ class FFmpegProtocol(Protocol):
 
     def input(
         self,
-        url: Union[str, os.PathLike],
+        url: Union[str, os.PathLike[str]],
         options: Optional[dict[str, Optional[types.Option]]] = None,
         **kwargs: Optional[types.Option],
     ) -> Self: ...
 
     def output(
         self,
-        url: Union[str, os.PathLike],
+        url: Union[str, os.PathLike[str]],
         options: Optional[dict[str, Optional[types.Option]]] = None,
         **kwargs: Optional[types.Option],
     ) -> Self: ...

--- a/ffmpeg/protocol.py
+++ b/ffmpeg/protocol.py
@@ -1,14 +1,18 @@
 from __future__ import annotations
 
 import os
-from typing import Any, Callable, Optional, Union
+from typing import Any, Awaitable, Callable, Final, Optional, Protocol, TypeVar, Union
 
-from typing_extensions import Protocol, Self, overload
+from typing_extensions import Self, TypeAlias
 
 from ffmpeg import types
 
+SyncExecute: TypeAlias = Callable[[Optional[types.Stream], Optional[float]], bytes]
+AsyncExecute: TypeAlias = Callable[[Optional[types.AsyncStream], Optional[float]], Awaitable[bytes]]
+ExecuteType_co = TypeVar("ExecuteType_co", SyncExecute, AsyncExecute, covariant=True)
 
-class FFmpegProtocol(Protocol):
+
+class FFmpegProtocol(Protocol[ExecuteType_co]):
     def __init__(self, executable: str = "ffmpeg"): ...
 
     @property
@@ -30,17 +34,7 @@ class FFmpegProtocol(Protocol):
         **kwargs: Optional[types.Option],
     ) -> Self: ...
 
-    @overload
-    def execute(
-        self,
-        stream: Optional[types.Stream] = None,
-    ) -> bytes: ...
-
-    @overload
-    async def execute(
-        self,
-        stream: Optional[types.AsyncStream] = None,
-    ) -> bytes: ...
+    execute: Final[ExecuteType_co]
 
     def terminate(self): ...
 

--- a/ffmpeg/types.py
+++ b/ffmpeg/types.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import asyncio
-from typing import IO, Callable, Iterable, TypeVar, Union
+from typing import IO, AsyncIterable, Callable, Iterable, TypeVar, Union
 
 Numeric = Union[int, float]
 
@@ -9,6 +9,6 @@ T = Union[str, Numeric]
 Option = Union[Iterable[T], T]
 
 Stream = Union[bytes, IO[bytes]]
-AsyncStream = Union[bytes, asyncio.StreamReader]
+AsyncStream = Union[bytes, asyncio.StreamReader, AsyncIterable[bytes]]
 
 Handler = TypeVar("Handler", bound=Callable[..., None])

--- a/setup.cfg
+++ b/setup.cfg
@@ -22,5 +22,5 @@ classifiers =
 install_requires =
     pyee
     typing_extensions
-python_requires = >=3.7
+python_requires = >=3.9
 packages = find:

--- a/tests/test_asyncio_async_iterable.py
+++ b/tests/test_asyncio_async_iterable.py
@@ -1,0 +1,47 @@
+import asyncio
+from pathlib import Path
+
+import pytest
+from helpers import probe
+
+from ffmpeg.asyncio import FFmpeg
+
+epsilon = 0.25
+
+
+async def yield_async_chunks(source_path: Path, sleep: float = 0.001, sleep_every: int = 1000):
+    with open(source_path, "rb") as source_file:
+        for i, source_bytes_chunk in enumerate(source_file):
+            yield source_bytes_chunk
+            if i % sleep_every == 0:
+                await asyncio.sleep(sleep)
+
+
+@pytest.mark.asyncio
+async def test_async_iterable_input_via_stdin(
+    assets_path: Path,
+    tmp_path: Path,
+):
+    source_path = assets_path / "pier-39.ts"
+    target_path = tmp_path / "pier-39.mp4"
+
+    ffmpeg = (
+        FFmpeg()
+        .option("y")
+        .input("pipe:0")
+        .output(
+            str(target_path),
+            codec="copy",
+        )
+    )
+
+    await ffmpeg.execute(yield_async_chunks(source_path))
+
+    source = probe(source_path)
+    target = probe(target_path)
+
+    assert abs(float(source["format"]["duration"]) - float(target["format"]["duration"])) <= epsilon
+    assert "mp4" in target["format"]["format_name"]
+
+    assert source["streams"][0]["codec_name"] == target["streams"][0]["codec_name"]
+    assert source["streams"][1]["codec_name"] == target["streams"][1]["codec_name"]


### PR DESCRIPTION
This PR is mostly a refactoring of the code base to cover the whole project with correct type-hints. Additionally it also:
- adds support for any `AsyncIterable[bytes]` as pipe input so virtually any asyncio-compatible source can be used
- removes support for python versions less than 3.9 which have reached end-of-life in 2024 and weren't properly supported anyways because of the reliance on [PEP 585](https://peps.python.org/pep-0585/)